### PR TITLE
pagination.pagerSize

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ enableEmoji = true
 title = 'iTheme'
 copyright = 'Floyd Li'
 theme = 'hugo-theme-itheme'
-paginate = 5
+pagerSize = 5
 [params]
   defaultCover = 'https://www.apple.com.cn/newsroom/images/apple-logo_black.jpg.landing-regular_2x.jpg'
   email = 'floyd.li@outlook.com'


### PR DESCRIPTION
The site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed. Use pagination.pagerSize instead.